### PR TITLE
Fix: Correct GitHub Actions workflow condition syntax

### DIFF
--- a/.github/workflows/bot-gemini.yml
+++ b/.github/workflows/bot-gemini.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   respond:
-    if: github.event.comment.body contains '@bot_gemini'
+    if: contains(github.event.comment.body, '@bot_gemini')
     runs-on: ubuntu-latest
     steps:
       - name: Say Hello


### PR DESCRIPTION
The `contains` function requires specific syntax in GitHub Actions expressions. This commit updates the workflow to use the correct `contains(haystack, needle)` format.